### PR TITLE
addition of coverage parsing cache

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public class Coverage {
 
-  private final Table<String, Integer, Integer> hitsByLineAndFile = HashBasedTable.create();
+  protected final Table<String, Integer, Integer> hitsByLineAndFile = HashBasedTable.create();
 
   public void addHits(String file, int line, int hits) {
     Integer oldHits = hitsByLineAndFile.get(file, line);

--- a/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
@@ -37,7 +37,9 @@ public class CoverageAggregator implements BatchExtension {
 
   public CoverageAggregator(CoverageConfiguration coverageConf, Settings settings) {
     this(coverageConf, settings,
-      new NCover3ReportParser(), new OpenCoverReportParser(), new DotCoverReportsAggregator(new DotCoverReportParser()), new VisualStudioCoverageXmlReportParser());
+      new NCover3ReportParser(),
+      new OpenCoverReportParser(),
+      new DotCoverReportsAggregator(new DotCoverReportParser()), new VisualStudioCoverageXmlReportParser());
   }
 
   @VisibleForTesting
@@ -76,23 +78,19 @@ public class CoverageAggregator implements BatchExtension {
   }
 
   public Coverage aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, Coverage coverage) {
-    if (hasNCover3ReportPaths()) {
-      aggregate(wildcardPatternFileProvider, settings.getString(coverageConf.ncover3PropertyKey()), ncover3ReportParser, coverage);
-    }
-
-    if (hasOpenCoverReportPaths()) {
-      aggregate(wildcardPatternFileProvider, settings.getString(coverageConf.openCoverPropertyKey()), openCoverReportParser, coverage);
-    }
-
-    if (hasDotCoverReportPaths()) {
-      aggregate(wildcardPatternFileProvider, settings.getString(coverageConf.dotCoverPropertyKey()), dotCoverReportsAggregator, coverage);
-    }
-
-    if (hasVisualStudioCoverageXmlReportPaths()) {
-      aggregate(wildcardPatternFileProvider, settings.getString(coverageConf.visualStudioCoverageXmlPropertyKey()), visualStudioCoverageXmlReportParser, coverage);
-    }
-
+    aggregateIfNeeded(wildcardPatternFileProvider, coverage, coverageConf.ncover3PropertyKey(), ncover3ReportParser);
+    aggregateIfNeeded(wildcardPatternFileProvider, coverage, coverageConf.openCoverPropertyKey(), openCoverReportParser);
+    aggregateIfNeeded(wildcardPatternFileProvider, coverage, coverageConf.dotCoverPropertyKey(), dotCoverReportsAggregator);
+    aggregateIfNeeded(wildcardPatternFileProvider, coverage, coverageConf.visualStudioCoverageXmlPropertyKey(), visualStudioCoverageXmlReportParser);
     return coverage;
+  }
+
+  private void aggregateIfNeeded(WildcardPatternFileProvider wildcardPatternFileProvider, Coverage coverage, String toolKey, CoverageParser parser) {
+    if (settings.hasKey(toolKey)) {
+      boolean useCache = settings.getBoolean(toolKey + ".useCache");
+      CoverageParser realParser = useCache ? new CoverageParserCache(parser) : parser;
+      aggregate(wildcardPatternFileProvider, settings.getString(toolKey), realParser, coverage);
+    }
   }
 
   private void aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, String reportPaths, CoverageParser parser, Coverage coverage) {

--- a/src/main/java/org/sonar/plugins/dotnet/tests/CoverageParserCache.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/CoverageParserCache.java
@@ -1,0 +1,73 @@
+/*
+ * SonarQube .NET Tests Library
+ * Copyright (C) 2014 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.dotnet.tests;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.google.common.collect.Table.Cell;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+public class CoverageParserCache implements CoverageParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoverageParserCache.class);
+  private final static Map<String, CachedCoverage> cache = Maps.newHashMap();
+  private final CoverageParser wrappedParser;
+
+  public CoverageParserCache(CoverageParser wrappedParser) {
+    super();
+    this.wrappedParser = wrappedParser;
+  }
+
+  @Override
+  public void parse(File file, Coverage coverage) {
+    String path = file.getAbsolutePath();
+    CachedCoverage cachedCoverage = cache.get(path);
+    if (cachedCoverage == null) {
+      cachedCoverage = new CachedCoverage();
+      wrappedParser.parse(file, cachedCoverage);
+      cache.put(path, cachedCoverage);
+      LOG.info("Caching coverage parsing for " + path);
+    } else {
+      LOG.info("Reusing cached coverage parsing for " + path);
+    }
+    cachedCoverage.mergeTo(coverage);
+  }
+
+  @VisibleForTesting
+  static void clear() {
+    cache.clear();
+  }
+
+  private class CachedCoverage extends Coverage {
+
+    public void mergeTo(Coverage coverage) {
+      //coverage.hitsByLineAndFile.putAll(this.hitsByLineAndFile);
+      for (Cell<String, Integer, Integer> cell : this.hitsByLineAndFile.cellSet()) {
+        coverage.addHits(cell.getRowKey(), cell.getColumnKey(), cell.getValue());
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'd like to propose this change to the community.

Using this change on a 150k lines project with 10Gb opencover reports for the run allowed me to get from 70 mins of run to 18 minutes by drastically reducing the time needed to parse the coverage reports on projects following the first one.