### PR TITLE
TRX Attributes considered mandatory are not actually mandatory.

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParser.java
@@ -73,13 +73,13 @@ public class VisualStudioTestResultsFileParser implements UnitTestResultsParser 
     private void handleCountersTag() {
       foundCounters = true;
 
-      int passed = xmlParserHelper.getRequiredIntAttribute("passed");
-      int failed = xmlParserHelper.getRequiredIntAttribute("failed");
-      int errors = xmlParserHelper.getRequiredIntAttribute("error");
-      int timeout = xmlParserHelper.getRequiredIntAttribute("timeout");
-      int aborted = xmlParserHelper.getRequiredIntAttribute("aborted");
+      int passed = xmlParserHelper.getOptionalIntAttribute("passed", 0);
+      int failed = xmlParserHelper.getOptionalIntAttribute("failed", 0);
+      int errors = xmlParserHelper.getOptionalIntAttribute("error", 0);
+      int timeout = xmlParserHelper.getOptionalIntAttribute("timeout", 0);
+      int aborted = xmlParserHelper.getOptionalIntAttribute("aborted", 0);
 
-      int inconclusive = xmlParserHelper.getRequiredIntAttribute("inconclusive");
+      int inconclusive = xmlParserHelper.getOptionalIntAttribute("inconclusive", 0);
 
       int tests = passed + failed + errors + timeout + aborted;
       int skipped = inconclusive;

--- a/src/main/java/org/sonar/plugins/dotnet/tests/XmlParserHelper.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/XmlParserHelper.java
@@ -94,6 +94,20 @@ public class XmlParserHelper {
       throw parseError("Expected an integer instead of \"" + value + "\" for the attribute \"" + name + "\"");
     }
   }
+  
+  public int getOptionalIntAttribute(String name, int defaultIfNotPresent) {
+    String value = getAttribute(name);
+    
+    if (value == null) {
+        return defaultIfNotPresent;
+    }
+	
+	try {
+	  return Integer.parseInt(value);
+	} catch (NumberFormatException e) {
+	  throw parseError("Expected an integer instead of \"" + value + "\" for the attribute \"" + name + "\"");
+	}
+  }
 
   public String getRequiredAttribute(String name) {
     String value = getAttribute(name);

--- a/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
@@ -59,6 +59,17 @@ public class VisualStudioTestResultsFileParserTest {
     assertThat(results.skipped()).isEqualTo(11);
     assertThat(results.failures()).isEqualTo(14);
     assertThat(results.errors()).isEqualTo(3);
-  }
+  }  
+  
+  @Test
+  public void valid_missing_failed() throws Exception {
+    UnitTestResults results = new UnitTestResults();
+    new VisualStudioTestResultsFileParser().parse(new File("src/test/resources/visualstudio_test_results/valid_missing_failed.trx"), results);
 
+    assertThat(results.tests()).isEqualTo(29);
+    assertThat(results.passedPercentage()).isEqualTo(14 * 100.0 / 29);
+    assertThat(results.skipped()).isEqualTo(11);
+    assertThat(results.failures()).isEqualTo(12);
+    assertThat(results.errors()).isEqualTo(3);
+  }
 }

--- a/src/test/resources/visualstudio_test_results/valid_missing_failed.trx
+++ b/src/test/resources/visualstudio_test_results/valid_missing_failed.trx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="0ecff956-7215-452f-9ce6-2b6d45870188" name="vagrant@WIN7PRO64 2014-06-11 15:48:58" runUser="WIN7PRO64\vagrant" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <ResultSummary outcome="Failed">
+    <Counters total="41" executed="40" passed="14" error="3" timeout="5" aborted="7" inconclusive="11" passedButRunAborted="0" notRunnable="0" notExecuted="1" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+  </ResultSummary>
+</TestRun>


### PR DESCRIPTION
I don't know if it's a TFS 2013 thing, but attributes that are considered mandatory by this code are not actually mandatory. (If all the tests fail, there will be no passed attribute)

Sample:
```
<ResultSummary outcome="Failed">
    <Counters total="28" executed="28" failed="28" />
    <CollectorDataEntries>
```