### PR TITLE
do no crash if metrics have been added already

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.sonar-plugins.dotnet.tests</groupId>
   <artifactId>sonar-dotnet-tests-library</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>1.3.1-SNAPSHOT</version>
 
   <name>SonarQube .NET Tests Library</name>
   <description />

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.sonar-plugins.dotnet.tests</groupId>
   <artifactId>sonar-dotnet-tests-library</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.3-SNAPSHOT</version>
 
   <name>SonarQube .NET Tests Library</name>
   <description />

--- a/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -26,9 +26,12 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.resources.Project;
 
 import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.SonarException;
 
 public class UnitTestResultsImportSensor implements Sensor {
-
+  private static final Logger LOG = LoggerFactory.getLogger(NUnitTestResultsFileParser.class);
   private final WildcardPatternFileProvider wildcardPatternFileProvider = new WildcardPatternFileProvider(new File("."), File.separator);
   private final UnitTestResultsAggregator unitTestResultsAggregator;
 
@@ -50,16 +53,21 @@ public class UnitTestResultsImportSensor implements Sensor {
 
   @VisibleForTesting
   void analyze(SensorContext context, UnitTestResults unitTestResults) {
-    UnitTestResults aggregatedResults = unitTestResultsAggregator.aggregate(wildcardPatternFileProvider, unitTestResults);
 
-    context.saveMeasure(CoreMetrics.TESTS, aggregatedResults.tests());
-    context.saveMeasure(CoreMetrics.TEST_ERRORS, aggregatedResults.errors());
-    context.saveMeasure(CoreMetrics.TEST_FAILURES, aggregatedResults.failures());
-    context.saveMeasure(CoreMetrics.SKIPPED_TESTS, aggregatedResults.skipped());
+    try
+    {
+      UnitTestResults aggregatedResults = unitTestResultsAggregator.aggregate(wildcardPatternFileProvider, unitTestResults);
 
-    if (aggregatedResults.tests() > 0) {
-      context.saveMeasure(CoreMetrics.TEST_SUCCESS_DENSITY, aggregatedResults.passedPercentage());
+      context.saveMeasure(CoreMetrics.TESTS, aggregatedResults.tests());
+      context.saveMeasure(CoreMetrics.TEST_ERRORS, aggregatedResults.errors());
+      context.saveMeasure(CoreMetrics.TEST_FAILURES, aggregatedResults.failures());
+      context.saveMeasure(CoreMetrics.SKIPPED_TESTS, aggregatedResults.skipped());
+
+      if (aggregatedResults.tests() > 0) {
+        context.saveMeasure(CoreMetrics.TEST_SUCCESS_DENSITY, aggregatedResults.passedPercentage());
+      }
+    } catch (SonarException ex) {
+      LOG.error("Test Metrics already saved: {0}", ex.getMessage());
     }
   }
-
 }

--- a/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -67,7 +67,7 @@ public class UnitTestResultsImportSensor implements Sensor {
         context.saveMeasure(CoreMetrics.TEST_SUCCESS_DENSITY, aggregatedResults.passedPercentage());
       }
     } catch (SonarException ex) {
-      LOG.error("Test Metrics already saved: {0}", ex.getMessage());
+      LOG.error("Test Metrics already saved: '{}'", ex.getMessage());
     }
   }
 }


### PR DESCRIPTION
when integration this library into fsharp plugin i run into analysis exceptions because the c# part has already imported unit test reports causing measure already added exception. 

@dbolkensteyn is there any way of fixing this without ignoring the exception?