### PR TITLE
introduce caching of Coverage information for VisualStudio Coverage Reports

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public class Coverage {
 
-  private final Table<String, Integer, Integer> hitsByLineAndFile = HashBasedTable.create();
+  private Table<String, Integer, Integer> hitsByLineAndFile = HashBasedTable.create();
 
   public void addHits(String file, int line, int hits) {
     Integer oldHits = hitsByLineAndFile.get(file, line);
@@ -49,5 +49,8 @@ public class Coverage {
   public Map<Integer, Integer> hits(String file) {
     return hitsByLineAndFile.row(file);
   }
-
+  
+  public void recycle(Coverage oldCoverage) {
+	  hitsByLineAndFile = oldCoverage.hitsByLineAndFile;
+  }
 }


### PR DESCRIPTION
We analyse project with a large amount on project in it (something between 50 and 800)

the size of the coverage report varies from 100MB up to 600MB. The parsing of a 150Mb File takes 67seconds. For an analysis with 50 Projects it takes nearly one hour in parsing each and everytime the same coverage report file.

with this caching i reduced the total runtime from more than one hour to 5minutes.