### PR TITLE
SONARNTEST-29 Speedup project analysis by caching code coverage reports

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
@@ -21,15 +21,15 @@ package org.sonar.plugins.dotnet.tests;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
+import java.io.File;
 import org.sonar.api.BatchExtension;
 import org.sonar.api.config.Settings;
-
-import java.io.File;
 
 public class CoverageAggregator implements BatchExtension {
 
   private final CoverageConfiguration coverageConf;
   private final Settings settings;
+  private final CoverageCache coverageCache;
   private final NCover3ReportParser ncover3ReportParser;
   private final OpenCoverReportParser openCoverReportParser;
   private final DotCoverReportsAggregator dotCoverReportsAggregator;
@@ -37,11 +37,16 @@ public class CoverageAggregator implements BatchExtension {
 
   public CoverageAggregator(CoverageConfiguration coverageConf, Settings settings) {
     this(coverageConf, settings,
-      new NCover3ReportParser(), new OpenCoverReportParser(), new DotCoverReportsAggregator(new DotCoverReportParser()), new VisualStudioCoverageXmlReportParser());
+      new CoverageCache(),
+      new NCover3ReportParser(),
+      new OpenCoverReportParser(),
+      new DotCoverReportsAggregator(new DotCoverReportParser()),
+      new VisualStudioCoverageXmlReportParser());
   }
 
   @VisibleForTesting
   public CoverageAggregator(CoverageConfiguration coverageConf, Settings settings,
+    CoverageCache coverageCache,
     NCover3ReportParser ncover3ReportParser,
     OpenCoverReportParser openCoverReportParser,
     DotCoverReportsAggregator dotCoverReportsAggregator,
@@ -49,6 +54,7 @@ public class CoverageAggregator implements BatchExtension {
 
     this.coverageConf = coverageConf;
     this.settings = settings;
+    this.coverageCache = coverageCache;
     this.ncover3ReportParser = ncover3ReportParser;
     this.openCoverReportParser = openCoverReportParser;
     this.dotCoverReportsAggregator = dotCoverReportsAggregator;
@@ -95,10 +101,10 @@ public class CoverageAggregator implements BatchExtension {
     return coverage;
   }
 
-  private static void aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, String reportPaths, CoverageParser parser, Coverage coverage) {
+  private void aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, String reportPaths, CoverageParser parser, Coverage aggregatedCoverage) {
     for (String reportPathPattern : Splitter.on(',').trimResults().omitEmptyStrings().split(reportPaths)) {
       for (File reportFile : wildcardPatternFileProvider.listFiles(reportPathPattern)) {
-        parser.parse(reportFile, coverage);
+        aggregatedCoverage.mergeWith(coverageCache.readCoverageFromCacheOrParse(parser, reportFile));
       }
     }
   }

--- a/src/main/java/org/sonar/plugins/dotnet/tests/CoverageCache.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/CoverageCache.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube .NET Tests Library
+ * Copyright (C) 2014-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.dotnet.tests;
+
+import java.io.File;
+import java.util.WeakHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CoverageCache {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoverageCache.class);
+
+  private final WeakHashMap<String, Coverage> cache = new WeakHashMap<>();
+
+  public Coverage readCoverageFromCacheOrParse(CoverageParser parser, File reportFile) {
+    String path = reportFile.getAbsolutePath();
+    Coverage coverage = cache.get(path);
+    if (coverage == null) {
+      coverage = new Coverage();
+      parser.parse(reportFile, coverage);
+      cache.put(path, coverage);
+      LOG.info("Adding this code coverage report to the cache for later reuse: " + path);
+    } else {
+      LOG.info("Successfully retrieved this code coverage report results from the cache: " + path);
+    }
+    return coverage;
+  }
+
+}

--- a/src/test/java/org/sonar/plugins/dotnet/tests/CoverageCacheTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/CoverageCacheTest.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube .NET Tests Library
+ * Copyright (C) 2014-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.dotnet.tests;
+
+import java.io.File;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CoverageCacheTest {
+
+  @Test
+  public void test() {
+    CoverageCache cache = new CoverageCache();
+    CoverageParser parser = mock(CoverageParser.class);
+    File reportFile = mock(File.class);
+    when(reportFile.getAbsolutePath()).thenReturn("foo.txt");
+
+    Coverage coverage = cache.readCoverageFromCacheOrParse(parser, reportFile);
+    verify(parser, Mockito.times(1)).parse(reportFile, coverage);
+
+    cache.readCoverageFromCacheOrParse(parser, reportFile);
+    verify(parser, Mockito.times(1)).parse(Mockito.eq(reportFile), Mockito.any(Coverage.class));
+  }
+
+}

--- a/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
@@ -1,0 +1,72 @@
+/*
+ * SonarQube .NET Tests Library
+ * Copyright (C) 2014-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.dotnet.tests;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class CoverageTest {
+
+  @Test
+  public void test() {
+    Coverage coverage = new Coverage();
+    assertThat(coverage.files()).isEmpty();
+    assertThat(coverage.hits("foo.txt")).isEmpty();
+
+    coverage.addHits("foo.txt", 42, 1);
+    assertThat(coverage.files()).containsOnly("foo.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 1));
+
+    coverage.addHits("foo.txt", 42, 3);
+    assertThat(coverage.files()).containsOnly("foo.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 4));
+
+    coverage.addHits("foo.txt", 1234, 11);
+    assertThat(coverage.files()).containsOnly("foo.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 4, 1234, 11));
+
+    coverage.addHits("bar.txt", 1, 2);
+    assertThat(coverage.files()).containsOnly("foo.txt", "bar.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 4, 1234, 11));
+    assertThat(coverage.hits("bar.txt")).isEqualTo(ImmutableMap.of(1, 2));
+
+    Coverage other = new Coverage();
+
+    coverage.mergeWith(other);
+    assertThat(coverage.files()).containsOnly("foo.txt", "bar.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 4, 1234, 11));
+    assertThat(coverage.hits("bar.txt")).isEqualTo(ImmutableMap.of(1, 2));
+
+    other.addHits("baz.txt", 2, 7);
+    assertThat(other.files()).containsOnly("baz.txt");
+    assertThat(other.hits("baz.txt")).isEqualTo(ImmutableMap.of(2, 7));
+
+    coverage.mergeWith(other);
+    assertThat(other.files()).containsOnly("baz.txt");
+    assertThat(other.hits("baz.txt")).isEqualTo(ImmutableMap.of(2, 7));
+    assertThat(coverage.files()).containsOnly("foo.txt", "bar.txt", "baz.txt");
+    assertThat(coverage.hits("foo.txt")).isEqualTo(ImmutableMap.of(42, 4, 1234, 11));
+    assertThat(coverage.hits("bar.txt")).isEqualTo(ImmutableMap.of(1, 2));
+    assertThat(coverage.hits("baz.txt")).isEqualTo(ImmutableMap.of(2, 7));
+  }
+
+}


### PR DESCRIPTION
Supercedes #11 and #17 

See https://jira.sonarsource.com/browse/SONARNTEST-29 for details.