### PR TITLE
Read the execution time from test results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>45000</maxsize>
+                  <maxsize>50000</maxsize>
                   <minsize>35000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
@@ -50,9 +50,19 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
         xmlParserHelper = new XmlParserHelper(file);
         checkRootTag();
         handleTestResultsTag();
+        dispatchTags();
       } finally {
         if (xmlParserHelper != null) {
           xmlParserHelper.close();
+        }
+      }
+    }
+
+    private void dispatchTags() {
+      String tagName;
+      while ((tagName = xmlParserHelper.nextTag()) != null) {
+        if ("test-suite".equals(tagName)) {
+          handleTestSuiteTag();
         }
       }
     }
@@ -73,6 +83,14 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
       int skipped = inconclusive + ignored;
 
       unitTestResults.add(tests, passed, skipped, failures, errors, 0);
+    }
+
+    private void handleTestSuiteTag() {
+      String timeAttribute = xmlParserHelper.getAttribute("time");
+
+      double time = Double.parseDouble(timeAttribute);
+
+      unitTestResults.add(0, 0, 0, 0, 0, (long)(time * 1000));
     }
   }
 

--- a/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
@@ -72,7 +72,7 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
       int passed = total - errors - failures - inconclusive;
       int skipped = inconclusive + ignored;
 
-      unitTestResults.add(tests, passed, skipped, failures, errors);
+      unitTestResults.add(tests, passed, skipped, failures, errors, 0);
     }
   }
 

--- a/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParser.java
@@ -23,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
 
 public class NUnitTestResultsFileParser implements UnitTestResultsParser {
 
@@ -88,9 +91,18 @@ public class NUnitTestResultsFileParser implements UnitTestResultsParser {
     private void handleTestSuiteTag() {
       String timeAttribute = xmlParserHelper.getAttribute("time");
 
-      double time = Double.parseDouble(timeAttribute);
+      long executionTime = 0;
 
-      unitTestResults.add(0, 0, 0, 0, 0, (long)(time * 1000));
+      try {
+         NumberFormat usFormat = NumberFormat.getInstance(Locale.US);
+         Number number = usFormat.parse(timeAttribute);
+         double time = number.doubleValue();
+         executionTime = (long)(time * 1000);
+      } catch(ParseException px) {
+        // Use the default value when we can't parse the input
+      }
+
+      unitTestResults.add(0, 0, 0, 0, 0, executionTime);
     }
   }
 

--- a/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResults.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResults.java
@@ -26,13 +26,15 @@ public class UnitTestResults {
   private int skipped;
   private int failures;
   private int errors;
+  private long executionTime;
 
-  public void add(int tests, int passed, int skipped, int failures, int errors) {
+  public void add(int tests, int passed, int skipped, int failures, int errors, long executionTime) {
     this.tests += tests;
     this.passed += passed;
     this.skipped += skipped;
     this.failures += failures;
     this.errors += errors;
+    this.executionTime += executionTime;
   }
 
   public double tests() {
@@ -55,4 +57,7 @@ public class UnitTestResults {
     return errors;
   }
 
+  public long executionTime() {
+    return executionTime;
+  }
 }

--- a/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -56,6 +56,7 @@ public class UnitTestResultsImportSensor implements Sensor {
     context.saveMeasure(CoreMetrics.TEST_ERRORS, aggregatedResults.errors());
     context.saveMeasure(CoreMetrics.TEST_FAILURES, aggregatedResults.failures());
     context.saveMeasure(CoreMetrics.SKIPPED_TESTS, aggregatedResults.skipped());
+    context.saveMeasure(CoreMetrics.TEST_EXECUTION_TIME, new Long(aggregatedResults.executionTime()).doubleValue());
 
     if (aggregatedResults.tests() > 0) {
       context.saveMeasure(CoreMetrics.TEST_SUCCESS_DENSITY, aggregatedResults.passedPercentage());

--- a/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -20,6 +20,9 @@
 package org.sonar.plugins.dotnet.tests;
 
 import java.io.File;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +74,20 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
       int failed = xmlParserHelper.getRequiredIntAttribute("failed");
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
       int errors = xmlParserHelper.getIntAttributeOrZero("errors");
+      String timeAsString = xmlParserHelper.getAttribute("time");
+      long executionTime = 0;
 
-      unitTestResults.add(total, passed, skipped, failed, errors, 0);
+
+      try {
+         NumberFormat usFormat = NumberFormat.getInstance(Locale.US);
+         Number number = usFormat.parse(timeAsString);
+         double time = number.doubleValue();
+         executionTime = (long)(time * 1000);
+      } catch(ParseException px) {
+        // Use the default value when we can't parse the input
+      }
+
+      unitTestResults.add(total, passed, skipped, failed, errors, executionTime);
     }
 
   }

--- a/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParser.java
@@ -72,7 +72,7 @@ public class XUnitTestResultsFileParser implements UnitTestResultsParser {
       int skipped = xmlParserHelper.getRequiredIntAttribute("skipped");
       int errors = xmlParserHelper.getIntAttributeOrZero("errors");
 
-      unitTestResults.add(total, passed, skipped, failed, errors);
+      unitTestResults.add(total, passed, skipped, failed, errors, 0);
     }
 
   }

--- a/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
@@ -61,4 +61,16 @@ public class NUnitTestResultsFileParserTest {
     assertThat(results.errors()).isEqualTo(30);
   }
 
+  @Test
+  public void valid_with_time() {
+    UnitTestResults results = new UnitTestResults();
+    new NUnitTestResultsFileParser().parse(new File("src/test/resources/nunit/nunit2_valid_with_time.xml"), results);
+
+    assertThat(results.tests()).isEqualTo(196);
+    assertThat(results.passedPercentage()).isEqualTo(146 * 100.0 / 196);
+    assertThat(results.skipped()).isEqualTo(7);
+    assertThat(results.failures()).isEqualTo(20);
+    assertThat(results.errors()).isEqualTo(30);
+    assertThat(results.executionTime()).isEqualTo(732);
+  }
 }

--- a/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensorTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensorTest.java
@@ -83,6 +83,7 @@ public class UnitTestResultsImportSensorTest {
     when(results.skipped()).thenReturn(1.0);
     when(results.failures()).thenReturn(2.0);
     when(results.errors()).thenReturn(3.0);
+    when(results.executionTime()).thenReturn(12345L);
     when(unitTestResultsAggregator.aggregate(Mockito.any(WildcardPatternFileProvider.class), Mockito.any(UnitTestResults.class))).thenReturn(results);
 
     new UnitTestResultsImportSensor(unitTestResultsAggregator).analyze(context, results);
@@ -92,6 +93,7 @@ public class UnitTestResultsImportSensorTest {
     verify(context).saveMeasure(CoreMetrics.SKIPPED_TESTS, 1.0);
     verify(context).saveMeasure(CoreMetrics.TEST_FAILURES, 2.0);
     verify(context).saveMeasure(CoreMetrics.TEST_ERRORS, 3.0);
+    verify(context).saveMeasure(CoreMetrics.TEST_EXECUTION_TIME, 12345.0);
     verify(context, Mockito.never()).saveMeasure(Mockito.eq(CoreMetrics.TEST_SUCCESS_DENSITY), Mockito.anyDouble());
   }
 

--- a/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioTestResultsFileParserTest.java
@@ -72,4 +72,11 @@ public class VisualStudioTestResultsFileParserTest {
     assertThat(results.errors()).isEqualTo(0);
   }
 
+  @Test
+  public void valid_with_duration() {
+    UnitTestResults results = new UnitTestResults();
+    new VisualStudioTestResultsFileParser().parse(new File("src/test/resources/visualstudio_test_results/valid_with_duration.trx"), results);
+
+    assertThat(results.executionTime()).isEqualTo(1000);
+  }
 }

--- a/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/XUnitTestResultsFileParserTest.java
@@ -66,6 +66,7 @@ public class XUnitTestResultsFileParserTest {
     assertThat(results.skipped()).isEqualTo(4);
     assertThat(results.failures()).isEqualTo(3);
     assertThat(results.errors()).isEqualTo(5);
+    assertThat(results.executionTime()).isEqualTo(455);
   }
 
   @Test
@@ -79,5 +80,4 @@ public class XUnitTestResultsFileParserTest {
     assertThat(results.failures()).isEqualTo(1);
     assertThat(results.errors()).isEqualTo(0);
   }
-
 }

--- a/src/test/resources/nunit/nunit2_valid_with_time.xml
+++ b/src/test/resources/nunit/nunit2_valid_with_time.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="c:\git\sonar-nunit\Sonar.NUnit\bin\Debug\Sonar.NUnit.dll" total="200" errors="30" failures="20" not-run="5" inconclusive="4" ignored="3" skipped="2" invalid="1" date="2014-08-15" time="09:02:13">
+  <environment nunit-version="2.6.0.12051" clr-version="2.0.50727.5483" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="c:\git\sonar-nunit" machine-name="machine" user="user" user-domain="domain" />
+  <culture-info current-culture="en-GB" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="SomeTests\NUnit.dll" executed="True" result="Failure" success="False" time="0.732" asserts="0">
+    <results />
+  </test-suite>
+</test-results>

--- a/src/test/resources/visualstudio_test_results/valid_with_duration.trx
+++ b/src/test/resources/visualstudio_test_results/valid_with_duration.trx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="0ecff956-7215-452f-9ce6-2b6d45870188" name="vagrant@WIN7PRO64 2014-06-11 15:48:58" runUser="WIN7PRO64\vagrant" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <ResultSummary outcome="Failed">
+    <Counters total="43" executed="42" passed="14" failed="2" error="3" timeout="5" aborted="7" inconclusive="11" passedButRunAborted="0" notRunnable="0" notExecuted="1" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+  </ResultSummary>
+  <Times creation="2012-02-19T09:25:24.8479038-05:00" queuing="2012-02-19T09:25:25.1799228-05:00" start="2012-02-19T09:25:25.1234567-05:00" finish="2012-02-19T09:25:26.1234567-05:00" />
+</TestRun>


### PR DESCRIPTION
While looking around the code for the issue mentioned here (http://stackoverflow.com/questions/29117785/no-drilldown-from-sonarqube-unit-test-success-widget) I got to the CoreMetrics and saw that there is an execution time metric that is currently not set via the unit test plugin.
This is an attempt at reading the value from a Visual Studio test result file.

Tests have been added for the VisualStudio result parser and the UnitTestResultsImportSensor classes however support for XUnit and NUnit is lacking right now, I could have a look at implementing that as well if that helps.

I'm not really happy with the try/catch in the parser, it's currently there because I don't know what the default behaviour is for a plugin when it encounters something weird in the input data. Does it look ok or should I just get rid of it altogether?