### PR TITLE
SONARNTEST-32 NUnit: Support ',' in addition to '.' in test execution…

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/XmlParserHelper.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/XmlParserHelper.java
@@ -121,6 +121,7 @@ public class XmlParserHelper {
   public double getRequiredDoubleAttribute(String name) {
     String value = getRequiredAttribute(name);
     try {
+      value = value.replace(',', '.');
       return Double.parseDouble(value);
     } catch (NumberFormatException e) {
       throw parseError("Expected an double instead of \"" + value + "\" for the attribute \"" + name + "\"");

--- a/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/NUnitTestResultsFileParserTest.java
@@ -61,4 +61,12 @@ public class NUnitTestResultsFileParserTest {
     assertThat(results.executionTime()).isEqualTo(51);
   }
 
+  @Test
+  public void valid_comma_in_double() throws Exception {
+    UnitTestResults results = new UnitTestResults();
+    new NUnitTestResultsFileParser().parse(new File("src/test/resources/nunit/valid_comma_in_double.xml"), results);
+
+    assertThat(results.executionTime()).isEqualTo(1051);
+  }
+
 }

--- a/src/test/java/org/sonar/plugins/dotnet/tests/XmlParserHelperTest.java
+++ b/src/test/java/org/sonar/plugins/dotnet/tests/XmlParserHelperTest.java
@@ -54,6 +54,7 @@ public class XmlParserHelperTest {
     XmlParserHelper xml = new XmlParserHelper(new File("src/test/resources/xml_parser_helper/valid.xml"));
     xml.nextStartTag();
     assertThat(xml.getRequiredDoubleAttribute("myDouble")).isEqualTo(0.123);
+    assertThat(xml.getRequiredDoubleAttribute("myCommaDouble")).isEqualTo(1.234);
 
     thrown.expectMessage("valid.xml");
     thrown.expectMessage("Expected an double instead of \"hello\" for the attribute \"myString\"");

--- a/src/test/resources/nunit/valid_comma_in_double.xml
+++ b/src/test/resources/nunit/valid_comma_in_double.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="c:\git\sonar-nunit\Sonar.NUnit\bin\Debug\Sonar.NUnit.dll" total="200" errors="30" failures="20" not-run="5" inconclusive="4" ignored="3" skipped="2" invalid="1" date="2014-08-15" time="09:02:13">
+  <environment nunit-version="2.6.0.12051" clr-version="2.0.50727.5483" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="c:\git\sonar-nunit" machine-name="machine" user="user" user-domain="domain" />
+  <culture-info current-culture="en-GB" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="C:\sonar-examples\projects\languages\csharp\NUnitTestProject1\bin\Debug\NUnitTestProject1.dll" executed="True" result="Success" success="True" time="1,051" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="NUnitTestProject1" executed="True" result="Success" success="True" time="1,046" asserts="0">
+        <results>
+          <test-suite type="TestFixture" name="NUnitTest1" executed="True" result="Success" success="True" time="1,045" asserts="0">
+            <results>
+              <test-case name="NUnitTestProject1.NUnitTest1.NUnitTestMethod1" executed="True" result="Success" success="True" time="1,041" asserts="2" />
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test/resources/xml_parser_helper/valid.xml
+++ b/src/test/resources/xml_parser_helper/valid.xml
@@ -1,3 +1,3 @@
-<foo myDouble="0.123" myString="hello">
+<foo myDouble="0.123" myCommaDouble="1,234" myString="hello">
   <bar c="0" />
 </foo>


### PR DESCRIPTION
… time numbers