### PR TITLE
Update UnitTestResultsImportSensor.java

### DIFF
--- a/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -42,7 +42,7 @@ public class UnitTestResultsImportSensor implements Sensor {
 
   @Override
   public void analyse(Project project, SensorContext context) {
-    if (project.isRoot()) {
+    if (!project.isRoot() || project.getModules().isEmpty()) {
       analyze(context, new UnitTestResults());
     }
   }


### PR DESCRIPTION
I wanted to analyse a multi-module project, so I created sonar-project.properties for each module where I specified sonar.cs.nunit.reportsPaths. But the condition in line 45 doesn't let sonar-runner to import reprorts for each module so I removed this condition and everything works.
But whene I analysed an other project with "MSBuild Sonarqube Runner" I had the error "Cannot add twice the same measure..." because the nunit report was imported twice by "MSBuild Sonarqube Runner". I looked for a solution for this issue and I found this condition ( !project.isRoot() || project.getModules().isEmpty() ) that can allow me to import reports in the two projects. I propose this file change in order to allow people to analyse multi-module projects.